### PR TITLE
 Add support for 7zz tool (more recent 7zip port)

### DIFF
--- a/multiarc/configs/plug/custom.ini
+++ b/multiarc/configs/plug/custom.ini
@@ -3,14 +3,14 @@ ID=01 43 44
 IDPos=32768
 TypeName=ISO7Z
 Extension=iso
-ToolNotFound=Please install 7z utility to open this archive
-List=7z l -- %%AQ
+ToolNotFound=Please install 7zz or 7z utility to open this archive
+List=7zz l -- %%AQ || 7z l -- %%AQ
 Start=------------------- ----- ------------ ------------  ------------------------
 End=------------------- ----- ------------ ------------  ------------------------
 Format0=yyyy-tt-dd hh:mm:ss aaaaa zzzzzzzzzzzz pppppppppppp  nnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnn
-Extract=7z x {-p%%P} -y %%AQ @%%LSM
-ExtractWithoutPath=7z e {-p%%P} -y %%AQ @%%LSM
-Test=7z t {-p%%P} -r0 %%AQ @%%LSM
+Extract=7zz x {-p%%P} -y %%AQ @%%LSM || 7z x {-p%%P} -y %%AQ @%%LSM
+ExtractWithoutPath=7zz e {-p%%P} -y %%AQ @%%LSM || 7z e {-p%%P} -y %%AQ @%%LSM
+Test=7zz t {-p%%P} -r0 %%AQ @%%LSM || 7z t {-p%%P} -r0 %%AQ @%%LSM
 AllFilesMask="*"
 
 [BY7Z]
@@ -66,14 +66,14 @@ ID13=EB 52 90 4E 54 46 53 20
 ID13Pos=0
 ;
 IDOnly=1
-ToolNotFound=Please install 7z utility to open this archive
-List=7z l -- %%AQ
+ToolNotFound=Please install 7zz or 7z utility to open this archive
+List=7zz l -- %%AQ || 7z l -- %%AQ
 Start=------------------- ----- ------------ ------------  ------------------------
 End=------------------- ----- ------------ ------------  ------------------------
 Format0=yyyy-tt-dd hh:mm:ss aaaaa zzzzzzzzzzzz pppppppppppp  nnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnn
-Extract=7z x {-p%%P} -y %%AQ @%%LSM
-ExtractWithoutPath=7z e {-p%%P} -y %%AQ @%%LSM
-Test=7z t {-p%%P} -r0 %%AQ @%%LSM
+Extract=7zz x {-p%%P} -y %%AQ @%%LSM || 7z x {-p%%P} -y %%AQ @%%LSM
+ExtractWithoutPath=7zz e {-p%%P} -y %%AQ @%%LSM || 7z e {-p%%P} -y %%AQ @%%LSM
+Test=7zz t {-p%%P} -r0 %%AQ @%%LSM || 7z t {-p%%P} -r0 %%AQ @%%LSM
 AllFilesMask="*"
 
 [MSI]
@@ -82,14 +82,14 @@ TypeName=MSI
 ID9=D0 CF 11 E0 A1 B1 1A E1
 ID9Pos=0
 Extension=msi
-ToolNotFound=Please install 7z utility to open this archive
-List=7z l -- %%AQ
+ToolNotFound=Please install 7zz or 7z utility to open this archive
+List=7zz l -- %%AQ || 7z l -- %%AQ
 Start=------------------- ----- ------------ ------------  ------------------------
 End=------------------- ----- ------------ ------------  ------------------------
 Format0=yyyy-tt-dd hh:mm:ss aaaaa zzzzzzzzzzzz pppppppppppp  nnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnn
-Extract=7z x {-p%%P} -y %%AQ @%%LSM
-ExtractWithoutPath=7z e {-p%%P} -y %%AQ @%%LSM
-Test=7z t {-p%%P} -r0 %%AQ @%%LSM
+Extract=7zz x {-p%%P} -y %%AQ @%%LSM || 7z x {-p%%P} -y %%AQ @%%LSM
+ExtractWithoutPath=7zz e {-p%%P} -y %%AQ @%%LSM || 7z e {-p%%P} -y %%AQ @%%LSM
+Test=7zz t {-p%%P} -r0 %%AQ @%%LSM || 7z t {-p%%P} -r0 %%AQ @%%LSM
 AllFilesMask="*"
 
 [IMG]

--- a/multiarc/src/formats/7z/7z.cpp
+++ b/multiarc/src/formats/7z/7z.cpp
@@ -275,17 +275,17 @@ BOOL WINAPI _export SEVENZ_GetDefaultCommands(int Type,int Command,char *Dest)
       /*Extract               */"^7z x %%A %%FMq*4096",
       /*Extract without paths */"^7z e %%A %%FMq*4096",
       /*Test                  */"^7z t %%A",
-      /*Delete                */"7z d {-p%%P} %%A @%%LN",
+      /*Delete                */"7zz d {-p%%P} %%A @%%LN || 7z d {-p%%P} %%A @%%LN",
       /*Comment archive       */"",
       /*Comment files         */"",
       /*Convert to SFX        */"",
       /*Lock archive          */"",
       /*Protect archive       */"",
       /*Recover archive       */"",
-      /*Add files             */"7z a -y {-p%%P} %%A @%%LN",
-      /*Move files            */"7z a -y -sdel {-p%%P} %%A @%%LN",
-      /*Add files and folders */"7z a -y {-p%%P} %%A @%%LN",
-      /*Move files and folders*/"7z a -y -sdel {-p%%P} %%A @%%LN",
+      /*Add files             */"7zz a -y {-p%%P} %%A @%%LN || 7z a -y {-p%%P} %%A @%%LN",
+      /*Move files            */"7zz a -y -sdel {-p%%P} %%A @%%LN || 7z a -y -sdel {-p%%P} %%A @%%LN",
+      /*Add files and folders */"7zz a -y {-p%%P} %%A @%%LN || 7z a -y {-p%%P} %%A @%%LN",
+      /*Move files and folders*/"7zz a -y -sdel {-p%%P} %%A @%%LN || 7z a -y -sdel {-p%%P} %%A @%%LN",
       /*"All files" mask      */"*"
     };
     if (Command<(int)(ARRAYSIZE(Commands)))


### PR DESCRIPTION
The 7zz tool, often supplied in the 7zip package, offers a more recent port of 7zip for Linux compared to the p7zip package version.