### PR TITLE
 e2k: autocomplete fix

### DIFF
--- a/far2l/src/vt/vtcompletor.cpp
+++ b/far2l/src/vt/vtcompletor.cpp
@@ -244,6 +244,13 @@ bool VTCompletor::TalkWithShell(const std::string &cmd, std::string &reply, cons
 	if (p != std::string::npos) {
 		reply.erase(0, p + begin.size());
 	}
+#ifdef __e2k__
+	p = reply.rfind('\a');
+	if (p == std::string::npos) {
+		reply = cmd;
+		return false;
+	}
+#endif
 	for (;;) {
 		p = reply.rfind('\a');
 		if (p == std::string::npos) break;


### PR DESCRIPTION
On e2k, autocomplete feature inserts garbage in command line due to bash sending the response in an unexpected format.