### PR TITLE
Allow using Ctrl+' as an alternative to Ctrl+`

### DIFF
--- a/far2l/src/panels/filelist.cpp
+++ b/far2l/src/panels/filelist.cpp
@@ -1322,7 +1322,9 @@ int FileList::ProcessKey(FarKey Key)
 			return TRUE;
 		}
 
-		case KEY_CTRL | '`': {
+		case KEY_CTRL | '`':
+		case KEY_CTRL | '\'':
+		{
 			SetLocation_Directory(CachedHomeDir());
 			return TRUE;
 		}


### PR DESCRIPTION
There are several reasons for that:
1. Ctrl+` do not work in plain tty mode
2. Ctrl+` also do not work in xterm even with ModifyOtherKeys=1
3. Ctrl+' is intuitive replacement for Ctrl+` that can be easily remembered
4. Changing folder to home folder is one of the most frequently needed actions. It should be available in any mode with any backend