### PR TITLE
Fix #2082 A fix for overlapping menus with panels (from far2m)

### DIFF
--- a/far2l/src/vmenu.cpp
+++ b/far2l/src/vmenu.cpp
@@ -1577,6 +1577,11 @@ void VMenu::DisplayObject()
 			SaveScr = new SaveScreen(X1, Y1, X2 + 2, Y2 + 1);
 	}
 
+	if (!CheckFlags(VMENU_LISTBOX)) {
+		DrawTitles();
+		WaitInMainLoop = FALSE;
+	}
+
 	ShowMenu(true, true);
 }
 


### PR DESCRIPTION
from: https://github.com/shmuz/far2m/commit/64454de160eb4fab17bdc2aa7b6558f0eebf81ce fix #2082