### PR TITLE
SetAttr: fix recursive file attributes/flags changing

### DIFF
--- a/far2l/src/setattr.cpp
+++ b/far2l/src/setattr.cpp
@@ -1700,8 +1700,8 @@ bool ShellSetFileAttributes(Panel *SrcPanel, LPCWSTR Object)
 											SkipMode = SETATTR_RET_SKIP;
 											continue;
 										}
-										ApplyFSFileFlags(AttrDlg, strFullName, FileAttr);
 									}
+									ApplyFSFileFlags(AttrDlg, strFullName, FileAttr);
 								}
 							}
 						}


### PR DESCRIPTION
Рекурсивное выставление атрибутов _(Immutable / Append / Hidden)_ для вложенных папок в диалоге Ctrl-A должно было происходить, но не отрабатывало потому, что было размещено не под той веткой if, и выполнялось только в том случае, если одновременно менялись права доступа.