### PR TITLE
build.yml: Remove duplicate libarchive-dev line

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -69,7 +69,6 @@ jobs:
          libx11-dev libxi-dev
          libssl-dev libsmbclient-dev libnfs-dev libneon27-dev libssh-dev
          libarchive-dev
-         libarchive-dev
          python3-dev python3-cffi
  
       - name: Create Build Environment


### PR DESCRIPTION
It was added because of bad conflict resolution in 56bb9cd42d4c49d7076ef058f1f9df012a165896.

Spotted by @akruphi.